### PR TITLE
CMakeLists: do not break native build on powerpc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,7 +211,7 @@ endif()
 
 if(NOT APPLE)
   if(NATIVE_BUILD)
-    if(CMAKE_SYSTEM_PROCESSOR STREQUAL ppc64le)
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "ppc*|power*")
       add_compile_options(-mcpu=native -mtune=native)
     else()
       add_compile_options(-march=native -mtune=native)


### PR DESCRIPTION
@majestrate Let’s perhaps fix this: there is no reason to break native builds on powerpc. Optimization flags work on Big endian ppc/ppc64.

P. S. I do not really get why this is excluded for macOS, arch optimization is supported on it across all 5 archs, but I leave that for now.