### PR TITLE
llarp/util/time: unbreak for non-Linux systems

### DIFF
--- a/llarp/util/time.cpp
+++ b/llarp/util/time.cpp
@@ -1,8 +1,6 @@
 #include "time.hpp"
-#include <linux/time_types.h>
 #include <chrono>
 #include <iomanip>
-#include "types.hpp"
 
 namespace llarp
 {
@@ -39,10 +37,11 @@ namespace llarp
     t.tv_nsec = ms * 1000000;
     return t;
   }
-  __kernel_timespec
+
+  llarp_timespec
   as_timespec(Duration_t d)
   {
-    return make_timespec<__kernel_timespec>(d);
+    return make_timespec<llarp_timespec>(d);
   }
 
   timespec

--- a/llarp/util/time.hpp
+++ b/llarp/util/time.hpp
@@ -4,7 +4,14 @@
 #include <iostream>
 #include <fmt/format.h>
 #include <fmt/chrono.h>
-#include <linux/time_types.h>
+
+#ifdef __linux__
+  #include <linux/time_types.h>
+  using llarp_timespec = __kernel_timespec;
+#else
+  #include <ctime>
+  using llarp_timespec = timespec;
+#endif
 
 using namespace std::chrono_literals;
 
@@ -18,7 +25,7 @@ namespace llarp
   Duration_t
   uptime();
 
-  __kernel_timespec as_timespec(Duration_t);
+  llarp_timespec as_timespec(Duration_t);
 
   timespec to_timespec(Duration_t);
 


### PR DESCRIPTION
@majestrate We will need something to this effect, the current code is non-portable (regardless of macOS support).
This is not tested, since the build does not work for different reasons. But it gets us past the error.