### PR TITLE
fmt::join was passing arguments in the wrong order.

### DIFF
--- a/llarp/util/str.hpp
+++ b/llarp/util/str.hpp
@@ -101,7 +101,7 @@ namespace llarp
   std::string
   join(std::string_view delimiter, It begin, It end)
   {
-    return fmt::format("{}", fmt::join(delimiter, begin, end));
+    return fmt::format("{}", fmt::join(begin, end, delimiter));
   }
 
   /// Wrapper around the above that takes a container and passes c.begin(), c.end() to the above.


### PR DESCRIPTION
this fixes that.