### PR TITLE
config.cpp: fix environ for macOS

### DIFF
--- a/llarp/config/config.cpp
+++ b/llarp/config/config.cpp
@@ -23,6 +23,14 @@
 #include <iostream>
 #include <map>
 
+#ifdef __APPLE__
+  #include <crt_externs.h>
+  #define llarp_environ (*_NSGetEnviron())
+#else
+  extern char **environ;
+  #define llarp_environ environ
+#endif
+
 namespace llarp
 {
   // constants for config file default values
@@ -53,7 +61,7 @@ namespace llarp
       EnvVarFetcher()
       {
         // clone enviorn global.
-        for (char** var{environ}; *var; ++var)
+        for (char** var = llarp_environ; *var; ++var)
         {
           std::string_view pair{*var};
           auto pos = pair.find_first_of('=');


### PR DESCRIPTION
@majestrate macOS is picky here. Linux-style declaration works on some macOS versions, but not all. The appropriate one is macOS-specific.