### PR TITLE
Minor fixes for build on macOS

### DIFF
--- a/llarp/constants/platform.hpp
+++ b/llarp/constants/platform.hpp
@@ -21,6 +21,15 @@ namespace llarp::platform
 #endif
       ;
 
+  ///  are we an apple platform ?
+  inline constexpr bool is_apple =
+#ifdef __APPLE__
+      true
+#else
+      false
+#endif
+      ;
+
   ///  are we freebsd ?
   inline constexpr bool is_freebsd =
 #ifdef __FreeBSD__

--- a/llarp/dns/server.cpp
+++ b/llarp/dns/server.cpp
@@ -20,6 +20,7 @@
 #include <llarp/util/logging.hpp>
 #include "sd_platform.hpp"
 #include "nm_platform.hpp"
+#include "apple_platform.hpp"
 
 namespace llarp::dns
 {
@@ -662,6 +663,8 @@ namespace llarp::dns
       plat->add_impl(std::make_unique<SD_Platform_t>());
       plat->add_impl(std::make_unique<NM_Platform_t>());
     }
+    if constexpr (llarp::platform::is_apple)
+      plat->add_impl(std::make_unique<Apple_Platform_t>());
     return plat;
   }
 

--- a/llarp/ev/libuv.cpp
+++ b/llarp/ev/libuv.cpp
@@ -18,6 +18,30 @@
 #include <llarp/util/fd.hpp>
 #include <uvw.hpp>
 
+#ifdef __APPLE__
+#ifndef MSG_NOSIGNAL
+#define MSG_NOSIGNAL 0
+#endif
+struct mmsghdr
+{
+  struct msghdr msg_hdr;
+  unsigned int msg_len;
+};
+static int
+sendmmsg(int fd, struct mmsghdr* msgvec, unsigned int vlen, int flags)
+{
+  unsigned int sent = 0;
+  for (; sent < vlen; sent++)
+  {
+    const ssize_t ret = ::sendmsg(fd, &msgvec[sent].msg_hdr, flags);
+    if (ret < 0)
+      return sent ? static_cast<int>(sent) : -1;
+    msgvec[sent].msg_len = static_cast<unsigned int>(ret);
+  }
+  return static_cast<int>(sent);
+}
+#endif  // __APPLE__
+
 namespace llarp::uv
 {
   static auto logcat = log::Cat("libuv");

--- a/llarp/vpn/apple.hpp
+++ b/llarp/vpn/apple.hpp
@@ -3,7 +3,9 @@
 #include "platform.hpp"
 #include "common.hpp"
 #include <llarp/vpn/common.hpp>
+#include <llarp/util/bits.hpp>
 #include <llarp/util/fd.hpp>
+#include <llarp/util/logging.hpp>
 #include <llarp/util/non_blocking.hpp>
 
 #include <sys/kern_control.h>
@@ -13,6 +15,7 @@
 #include <sys/types.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
+#include <sys/sysctl.h>
 #include <sys/param.h>
 #include <sys/uio.h>
 
@@ -32,19 +35,66 @@
 #include <string.h>
 #include <unistd.h>
 #include <errno.h>
+#include <algorithm>
 #include <variant>
+#include <vector>
 
 namespace llarp::vpn
 {
+  // The lo0 host route for the tun address must be removed when the daemon
+  // exits, but the AppleInterface object is retained by event-loop handles
+  // beyond context teardown, so its destructor does not reliably run before
+  // process exit.  Track added routes and flush them via atexit(3); the
+  // handler must not log, as logging may already be torn down by then.
+  namespace apple_route_cleanup
+  {
+    inline std::vector<std::string>&
+    Routes()
+    {
+      // Deliberately heap-allocated and never freed: atexit handlers and
+      // static destructors run interleaved in reverse registration order, so
+      // a plain static vector could be destroyed before Flush() runs and it
+      // would then iterate a dead object.  A leaked vector has no destructor
+      // to register, making Flush() safe no matter when it fires.
+      static auto* routes = new std::vector<std::string>();
+      return *routes;
+    }
+
+    inline void
+    Flush()
+    {
+      for (const auto& ip : Routes())
+        ::system(("/sbin/route -n delete -host " + ip + " -interface lo0").c_str());
+      Routes().clear();
+    }
+
+    inline void
+    Track(std::string ip)
+    {
+      static bool registered = (::atexit(&Flush), true);
+      (void)registered;
+      Routes().push_back(std::move(ip));
+    }
+  }  // namespace apple_route_cleanup
+
+  // UTUN_OPT_IFNAME from <net/if_utun.h>, hardcoded so we don't depend on that
+  // header existing in older SDKs.
+  inline constexpr int apple_utun_opt_ifname = 2;
+
   class AppleInterface : public NetworkInterface
   {
     std::unique_ptr<util::FD> m_FD;
 
-    static int
-    Exec(const std::string& cmd)
+    static void
+    Exec(const std::string& cmd, bool must_succeed = true)
     {
-      return system(cmd.c_str());
+      static auto logcat = log::Cat("vpn.apple");
+      log::info(logcat, "exec: {}", cmd);
+      if (int ret = ::system(cmd.c_str()); ret != 0 and must_succeed)
+        throw std::runtime_error{"command failed (" + std::to_string(ret) + "): " + cmd};
     }
+
+    friend class AppleRouteManager;
 
    public:
     AppleInterface(InterfaceInfo info)
@@ -68,7 +118,7 @@ namespace llarp::vpn
       addr.sc_len = sizeof(addr);
       addr.sc_family = AF_SYSTEM;
       addr.ss_sysaddr = AF_SYS_CONTROL;
-      addr.sc_unit = 0;
+      addr.sc_unit = 0;  // kernel picks the first free utunN
 
       if (::connect(m_FD->fd(), (sockaddr*)&addr, sizeof(addr)) < 0)
       {
@@ -78,7 +128,8 @@ namespace llarp::vpn
       }
       uint32_t namesz = IFNAMSIZ;
       std::array<char, IFNAMSIZ + 1> name{};
-      if (::getsockopt(m_FD->fd(), SYSPROTO_CONTROL, 2, name.data(), &namesz) < 0)
+      if (::getsockopt(m_FD->fd(), SYSPROTO_CONTROL, apple_utun_opt_ifname, name.data(), &namesz)
+          < 0)
       {
         m_FD.reset();
         throw std::runtime_error{
@@ -90,29 +141,57 @@ namespace llarp::vpn
 
       auto& m_IfName = m_Info.ifname;
       m_IfName = name.data();
+      m_Info.index = if_nametoindex(m_IfName.c_str());
       for (const auto& ifaddr : m_Info.addrs)
       {
         if (ifaddr.fam == AF_INET)
         {
-          const huint32_t addr = net::TruncateV6(ifaddr.range.addr);
-          const huint32_t netmask = net::TruncateV6(ifaddr.range.netmask_bits);
+          const huint32_t addr = net::ToHost(net::TruncateV6(ifaddr.range.addr));
+          const huint32_t netmask = net::ToHost(net::TruncateV6(ifaddr.range.netmask_bits));
           const huint32_t daddr = addr & netmask;
+          // utun is point-to-point only; use the OpenVPN-style "topology subnet"
+          // trick: /32 p2p pair to the network base address, then route the whole
+          // range at the interface.
           Exec(
               "/sbin/ifconfig " + m_IfName + " " + addr.ToString() + " " + daddr.ToString()
-              + " mtu 1500 netmask 255.255.255.255 up");
+              + " mtu " + std::to_string(m_Info.mtu) + " netmask 255.255.255.255 up");
           Exec(
-              "/sbin/route add " + daddr.ToString() + " -netmask " + netmask.ToString()
+              "/sbin/route -n add -net " + daddr.ToString() + " -netmask " + netmask.ToString()
               + " -interface " + m_IfName);
-          Exec("/sbin/route add " + addr.ToString() + " -interface lo0");
+          // our own tun address is local, macOS wants it via loopback:
+          Exec("/sbin/route -n add -host " + addr.ToString() + " -interface lo0");
+          apple_route_cleanup::Track(addr.ToString());
         }
         else if (ifaddr.fam == AF_INET6)
         {
-          Exec("/sbin/ifconfig " + m_IfName + " inet6 " + ifaddr.range.ToString());
+          const auto prefixlen = bits::count_bits(ifaddr.range.netmask_bits);
+          Exec(
+              "/sbin/ifconfig " + m_IfName + " inet6 " + ifaddr.range.addr.ToString()
+              + " prefixlen " + std::to_string(prefixlen) + " up");
+          Exec(
+              "/sbin/route -n add -inet6 -net " + ifaddr.range.addr.ToString() + " -prefixlen "
+                  + std::to_string(prefixlen) + " -interface " + m_IfName,
+              false);
         }
       }
     }
 
-    ~AppleInterface() override = default;
+    ~AppleInterface() override
+    {
+      // Normally unreachable before process exit (see apple_route_cleanup);
+      // when it does run, clean up here and de-register so the atexit flush
+      // does not delete the same routes twice.
+      auto& routes = apple_route_cleanup::Routes();
+      for (const auto& ifaddr : m_Info.addrs)
+      {
+        if (ifaddr.fam == AF_INET)
+        {
+          const auto ip = net::TruncateV6(ifaddr.range.addr).ToString();
+          Exec("/sbin/route -n delete -host " + ip + " -interface lo0", false);
+          routes.erase(std::remove(routes.begin(), routes.end(), ip), routes.end());
+        }
+      }
+    }
 
     int
     PollFD() const override
@@ -126,22 +205,27 @@ namespace llarp::vpn
       constexpr int uintsize = sizeof(unsigned int);
       net::IPPacket pkt{net::IPPacket::MaxSize};
 
-      // Prepare storage for header + max-size packet.
+      // Each utun datagram is prefixed with a 4-byte address family header.
       unsigned int pktinfo = 0;
       std::array<iovec, 2> vecs = {iovec{&pktinfo, uintsize}, iovec{pkt.data(), pkt.size()}};
-      int sz = ::readv(m_FD->fd(), vecs.data(), vecs.size());
+      auto sz = ::readv(m_FD->fd(), vecs.data(), vecs.size());
       if (sz >= uintsize)
       {
         pkt.truncate(sz - uintsize);  // shrink to actual size
       }
-      else if (errno == EAGAIN || errno == EWOULDBLOCK)
+      else if (sz < 0)
+      {
+        if (errno == EAGAIN || errno == EWOULDBLOCK)
+        {
+          pkt.truncate(0);
+          errno = 0;
+        }
+        else
+          throw std::error_code{errno, std::system_category()};
+      }
+      else  // 0 <= sz < uintsize: short read of the AF header; drop it
       {
         pkt.truncate(0);
-        errno = 0;
-      }
-      else
-      {
-        throw std::error_code{errno, std::system_category()};
       }
       return pkt;
     }
@@ -170,85 +254,178 @@ namespace llarp::vpn
 
   class AppleRouteManager : public IRouteManager
   {
+    static void
+    Exec(const std::string& cmd, bool must_succeed = true)
+    {
+      AppleInterface::Exec(cmd, must_succeed);
+    }
+
+    static std::string
+    FamilyFlag(const net::ipaddr_t& ip)
+    {
+      if (std::holds_alternative<net::ipv6addr_t>(ip))
+        return "-inet6 ";
+      return "";
+    }
+
    public:
     AppleRouteManager() = default;
     ~AppleRouteManager() override = default;
 
-    // Add a route to a specific IP via a gateway
+    // Add a first-hop hole-poke route to a specific IP via a physical gateway
     void
     AddRoute(net::ipaddr_t ip, net::ipaddr_t gateway) override
     {
-      std::string cmd =
-          "/sbin/route add -host " + llarp::net::ToString(ip) + " " + llarp::net::ToString(gateway);
-      int ret = std::system(cmd.c_str());
-      if (ret != 0)
-        throw std::runtime_error("AddRoute failed: " + cmd);
+      Exec(
+          "/sbin/route -n add " + FamilyFlag(ip) + "-host " + llarp::net::ToString(ip) + " "
+          + llarp::net::ToString(gateway));
     }
 
     void
     DelRoute(net::ipaddr_t ip, net::ipaddr_t gateway) override
     {
-      std::string cmd = "/sbin/route delete -host " + llarp::net::ToString(ip) + " "
-          + llarp::net::ToString(gateway);
-      int ret = std::system(cmd.c_str());
-      if (ret != 0)
-        throw std::runtime_error("DelRoute failed: " + cmd);
+      Exec(
+          "/sbin/route -n delete " + FamilyFlag(ip) + "-host " + llarp::net::ToString(ip) + " "
+              + llarp::net::ToString(gateway),
+          false);
     }
 
-    // Add a default route via the VPN interface's first IPv4 address
+    // Capture all traffic at the tun interface WITHOUT touching the existing
+    // default route: two /1 routes (plus four /2s for IPv6) are more specific
+    // than "default", so the original gateway stays in the table for the
+    // hole-poked first-hop routes added above.
     void
     AddDefaultRouteViaInterface(NetworkInterface& vpn) override
     {
-      const auto& info = vpn.Info();
-      if (info.addrs.empty())
-        throw std::runtime_error("No interface addresses found");
+      const auto& ifname = vpn.Info().ifname;
+      for (const auto* range : {"0.0.0.0/1", "128.0.0.0/1"})
+        Exec(std::string{"/sbin/route -n add -net "} + range + " -interface " + ifname);
 
-      std::string gateway = info.addrs[0].range.addr.ToString();
-      std::string cmd = "/sbin/route add default " + gateway;
-      int ret = std::system(cmd.c_str());
-      if (ret != 0)
-        throw std::runtime_error("AddDefaultRouteViaInterface failed: " + cmd);
+      bool have_v6 = false;
+      for (const auto& addr : vpn.Info().addrs)
+        have_v6 |= (addr.fam == AF_INET6);
+      if (have_v6)
+        for (const auto* base : {"::", "4000::", "8000::", "c000::"})
+          Exec(
+              std::string{"/sbin/route -n add -inet6 -net "} + base + " -prefixlen 2 -interface "
+                  + ifname,
+              false);
     }
 
     void
     DelDefaultRouteViaInterface(NetworkInterface& vpn) override
     {
-      const auto& info = vpn.Info();
-      if (info.addrs.empty())
-        throw std::runtime_error("No interface addresses found");
+      const auto& ifname = vpn.Info().ifname;
+      for (const auto* range : {"0.0.0.0/1", "128.0.0.0/1"})
+        Exec(std::string{"/sbin/route -n delete -net "} + range + " -interface " + ifname, false);
 
-      std::string gateway = info.addrs[0].range.addr.ToString();
-      std::string cmd = "/sbin/route delete default " + gateway;
-      int ret = std::system(cmd.c_str());
-      if (ret != 0)
-        throw std::runtime_error("DelDefaultRouteViaInterface failed: " + cmd);
+      for (const auto* base : {"::", "4000::", "8000::", "c000::"})
+        Exec(
+            std::string{"/sbin/route -n delete -inet6 -net "} + base + " -prefixlen 2 -interface "
+                + ifname,
+            false);
     }
 
     // Add a route for a subnet via the VPN interface
     void
     AddRouteViaInterface(NetworkInterface& vpn, IPRange range) override
     {
-      std::string cmd = "/sbin/route add -net " + range.addr.ToString() + " -netmask "
-          + range.NetmaskString() + " -interface " + vpn.Info().ifname;
-      int ret = std::system(cmd.c_str());
-      if (ret != 0)
-        throw std::runtime_error("AddRouteViaInterface failed: " + cmd);
+      const auto& ifname = vpn.Info().ifname;
+      if (range.IsV4())
+        Exec(
+            "/sbin/route -n add -net " + net::TruncateV6(range.addr).ToString() + " -netmask "
+            + range.NetmaskString() + " -interface " + ifname);
+      else
+        Exec(
+            "/sbin/route -n add -inet6 -net " + range.addr.ToString() + " -prefixlen "
+            + std::to_string(bits::count_bits(range.netmask_bits)) + " -interface " + ifname);
     }
 
     void
     DelRouteViaInterface(NetworkInterface& vpn, IPRange range) override
     {
-      std::string cmd = "/sbin/route delete -net " + range.addr.ToString() + " -netmask "
-          + range.NetmaskString() + " -interface " + vpn.Info().ifname;
-      int ret = std::system(cmd.c_str());
-      if (ret != 0)
-        throw std::runtime_error("DelRouteViaInterface failed: " + cmd);
+      const auto& ifname = vpn.Info().ifname;
+      if (range.IsV4())
+        Exec(
+            "/sbin/route -n delete -net " + net::TruncateV6(range.addr).ToString() + " -netmask "
+                + range.NetmaskString() + " -interface " + ifname,
+            false);
+      else
+        Exec(
+            "/sbin/route -n delete -inet6 -net " + range.addr.ToString() + " -prefixlen "
+                + std::to_string(bits::count_bits(range.netmask_bits)) + " -interface " + ifname,
+            false);
     }
 
+    // Enumerate default-route gateways that do NOT live on the tun interface,
+    // by dumping the routing table via the classic BSD sysctl interface.  The
+    // route poker uses this to find the physical gateway for hole-poking.
     std::vector<net::ipaddr_t>
-    GetGatewaysNotOnInterface(NetworkInterface&) override
+    GetGatewaysNotOnInterface(NetworkInterface& vpn) override
     {
-      return {};
+      std::vector<net::ipaddr_t> gateways;
+      const unsigned int tun_index = if_nametoindex(vpn.Info().ifname.c_str());
+
+      int mib[6] = {CTL_NET, PF_ROUTE, 0, 0 /* all families */, NET_RT_FLAGS, RTF_GATEWAY};
+      size_t needed = 0;
+      if (sysctl(mib, 6, nullptr, &needed, nullptr, 0) != 0)
+        return gateways;
+      std::vector<char> buf;
+      buf.resize(needed);
+      if (sysctl(mib, 6, buf.data(), &needed, nullptr, 0) != 0)
+        return gateways;
+
+      // routing socket sockaddrs are packed with 4-byte alignment; sa_len == 0
+      // still occupies one alignment unit
+      constexpr auto align = sizeof(uint32_t);
+      const auto sa_size = [](const sockaddr* sa) {
+        return sa->sa_len ? ((sa->sa_len + align - 1) & ~(align - 1)) : align;
+      };
+
+      for (char* ptr = buf.data(); ptr + sizeof(rt_msghdr) <= buf.data() + needed;)
+      {
+        auto* rtm = reinterpret_cast<rt_msghdr*>(ptr);
+        if (rtm->rtm_msglen == 0)
+          break;
+        char* addrs = ptr + sizeof(rt_msghdr);
+        ptr += rtm->rtm_msglen;
+
+        if (rtm->rtm_version != RTM_VERSION)
+          continue;
+        if ((rtm->rtm_flags & (RTF_UP | RTF_GATEWAY)) != (RTF_UP | RTF_GATEWAY))
+          continue;
+        if (rtm->rtm_index == tun_index)
+          continue;  // route lives on our own interface
+        if ((rtm->rtm_addrs & (RTA_DST | RTA_GATEWAY)) != (RTA_DST | RTA_GATEWAY))
+          continue;
+
+        const sockaddr* dst = nullptr;
+        const sockaddr* gw = nullptr;
+        char* sa_ptr = addrs;
+        for (int i = 0; i < RTAX_MAX; i++)
+        {
+          if (not(rtm->rtm_addrs & (1 << i)))
+            continue;
+          auto* sa = reinterpret_cast<const sockaddr*>(sa_ptr);
+          if (i == RTAX_DST)
+            dst = sa;
+          else if (i == RTAX_GATEWAY)
+            gw = sa;
+          sa_ptr += sa_size(sa);
+        }
+        if (not dst or not gw)
+          continue;
+
+        // only default routes (dst 0.0.0.0); the poker only consumes IPv4
+        if (dst->sa_family != AF_INET or gw->sa_family != AF_INET)
+          continue;
+        if (reinterpret_cast<const sockaddr_in*>(dst)->sin_addr.s_addr != 0)
+          continue;
+
+        gateways.emplace_back(
+            net::ipv4addr_t{reinterpret_cast<const sockaddr_in*>(gw)->sin_addr.s_addr});
+      }
+      return gateways;
     }
   };
 


### PR DESCRIPTION
1. Forgotten patch to fix linking.
2. Provisional fix for:
```
[ 18%] Building CXX object llarp/CMakeFiles/lokinet-platform.dir/net/posix.cpp.o
cd /opt/local/var/macports/build/llarp-devel-622b328a/work/build/llarp && /opt/local/bin/clang++-mp-17 -DLOGGING_SOURCE_ROOT=\"/opt/local/var/macports/build/llarp-devel-622b328a/work/llarp-de156af2be35ef5693a4133429ff8d4bf19c85ae\" -DPOSIX -DSPDLOG_COMPILED_LIB -DUNIX -I/opt/local/var/macports/build/llarp-devel-622b328a/work/llarp-de156af2be35ef5693a4133429ff8d4bf19c85ae/external/uvw/src -I/opt/local/var/macports/build/llarp-devel-622b328a/work/llarp-de156af2be35ef5693a4133429ff8d4bf19c85ae -I/opt/local/var/macports/build/llarp-devel-622b328a/work/llarp-de156af2be35ef5693a4133429ff8d4bf19c85ae/include -I/opt/local/var/macports/build/llarp-devel-622b328a/work/llarp-de156af2be35ef5693a4133429ff8d4bf19c85ae/external/spdlog/include -I/opt/local/var/macports/build/llarp-devel-622b328a/work/llarp-de156af2be35ef5693a4133429ff8d4bf19c85ae/external/fmt/include -I/opt/local/var/macports/build/llarp-devel-622b328a/work/llarp-de156af2be35ef5693a4133429ff8d4bf19c85ae/crypto/libntrup/include -isystem /opt/local/include -pipe -I/opt/local/libexec/openssl3/include -DNDEBUG -I/opt/local/libexec/openssl3/include -isystem/opt/local/include -stdlib=libc++ -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk -std=c++20 -arch x86_64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk -mmacosx-version-min=10.15 -fPIC -Wall -Wextra -Wno-unknown-pragmas -Wno-unused-function -Werror=vla -Wno-unknown-warning-option -Wno-deprecated-declarations -march=nocona -mtune=haswell -mfpmath=sse -MD -MT llarp/CMakeFiles/lokinet-platform.dir/net/posix.cpp.o -MF CMakeFiles/lokinet-platform.dir/net/posix.cpp.o.d -o CMakeFiles/lokinet-platform.dir/net/posix.cpp.o -c /opt/local/var/macports/build/llarp-devel-622b328a/work/llarp-de156af2be35ef5693a4133429ff8d4bf19c85ae/llarp/net/posix.cpp
In file included from /opt/local/var/macports/build/llarp-devel-622b328a/work/llarp-de156af2be35ef5693a4133429ff8d4bf19c85ae/llarp/vpn/platform.cpp:15:
/opt/local/var/macports/build/llarp-devel-622b328a/work/llarp-de156af2be35ef5693a4133429ff8d4bf19c85ae/llarp/vpn/apple.hpp:104:27: error: no viable conversion from 'ipv4addr_t' (aka 'nuint_t<unsigned int>') to 'const huint32_t' (aka 'const huint_t<unsigned int>')
  104 |           const huint32_t addr = net::TruncateV6(ifaddr.range.addr);
      |                           ^      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/local/var/macports/build/llarp-devel-622b328a/work/llarp-de156af2be35ef5693a4133429ff8d4bf19c85ae/llarp/net/net_int.hpp:22:10: note: candidate constructor (the implicit copy constructor) not viable: no known conversion from 'ipv4addr_t' (aka 'nuint_t<unsigned int>') to 'const huint_t<unsigned int> &' for 1st argument
   22 |   struct huint_t
      |          ^~~~~~~
/opt/local/var/macports/build/llarp-devel-622b328a/work/llarp-de156af2be35ef5693a4133429ff8d4bf19c85ae/llarp/net/net_int.hpp:22:10: note: candidate constructor (the implicit move constructor) not viable: no known conversion from 'ipv4addr_t' (aka 'nuint_t<unsigned int>') to 'huint_t<unsigned int> &&' for 1st argument
   22 |   struct huint_t
      |          ^~~~~~~
In file included from /opt/local/var/macports/build/llarp-devel-622b328a/work/llarp-de156af2be35ef5693a4133429ff8d4bf19c85ae/llarp/vpn/platform.cpp:15:
/opt/local/var/macports/build/llarp-devel-622b328a/work/llarp-de156af2be35ef5693a4133429ff8d4bf19c85ae/llarp/vpn/apple.hpp:105:27: error: no viable conversion from 'ipv4addr_t' (aka 'nuint_t<unsigned int>') to 'const huint32_t' (aka 'const huint_t<unsigned int>')
  105 |           const huint32_t netmask = net::TruncateV6(ifaddr.range.netmask_bits);
      |                           ^         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/local/var/macports/build/llarp-devel-622b328a/work/llarp-de156af2be35ef5693a4133429ff8d4bf19c85ae/llarp/net/net_int.hpp:22:10: note: candidate constructor (the implicit copy constructor) not viable: no known conversion from 'ipv4addr_t' (aka 'nuint_t<unsigned int>') to 'const huint_t<unsigned int> &' for 1st argument
   22 |   struct huint_t
      |          ^~~~~~~
/opt/local/var/macports/build/llarp-devel-622b328a/work/llarp-de156af2be35ef5693a4133429ff8d4bf19c85ae/llarp/net/net_int.hpp:22:10: note: candidate constructor (the implicit move constructor) not viable: no known conversion from 'ipv4addr_t' (aka 'nuint_t<unsigned int>') to 'huint_t<unsigned int> &&' for 1st argument
   22 |   struct huint_t
      |          ^~~~~~~
2 errors generated.
```